### PR TITLE
fix: add Windows support for OAuth browser open and User-Agent header

### DIFF
--- a/src/platforms/slack/auth/login.ts
+++ b/src/platforms/slack/auth/login.ts
@@ -106,10 +106,15 @@ async function loginWithOAuth(
       process.platform === "darwin"
         ? "open"
         : process.platform === "win32"
-          ? "start"
+          ? "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
           : "xdg-open";
 
-    Bun.spawn([openCmd, authUrl.toString()], {
+    const openArgs =
+      process.platform === "win32"
+        ? [openCmd, "-NoProfile", "-Command", `Start-Process "${authUrl.toString()}"`]
+        : [openCmd, authUrl.toString()];
+
+    Bun.spawn(openArgs, {
       stdout: "ignore",
       stderr: "ignore",
     });

--- a/src/platforms/slack/client.ts
+++ b/src/platforms/slack/client.ts
@@ -3,5 +3,6 @@ import { WebClient } from "@slack/web-api";
 export function createSlackClient(token: string): WebClient {
   return new WebClient(token, {
     retryConfig: { retries: 3 },
+    headers: { "User-Agent": "holla-cli" },
   });
 }


### PR DESCRIPTION
## **User description**
Use PowerShell Start-Process for opening the browser on Windows since Bun.spawn cannot invoke cmd.exe built-in commands. Also set an explicit User-Agent header to avoid invalid characters in compiled binaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth browser launch mechanism on Windows for more reliable authentication flow.

* **Improvements**
  * Enhanced Slack client integration with better server communication identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Fix OAuth browser launch on Windows and set explicit Slack User-Agent

### What Changed
- OAuth now launches the system browser on Windows using PowerShell Start-Process so the authentication page opens reliably during login
- Slack client requests include an explicit User-Agent header ("holla-cli") to avoid invalid characters in compiled binaries and make requests easier to identify

### Impact
`✅ Fewer OAuth timeouts on Windows`
`✅ Fewer Slack API request rejections due to malformed headers`
`✅ Clearer client identification in server logs`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
