### PR TITLE
fix: create cache dir before writing channel/user cache (#28)

### DIFF
--- a/src/platforms/slack/resolve.ts
+++ b/src/platforms/slack/resolve.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path";
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { getCacheDir } from "../../lib/config.ts";
 import type { WebClient } from "@slack/web-api";
 import type { CacheEntry } from "../../types/index.ts";
@@ -54,7 +54,9 @@ async function loadCache(workspace: string, key: string): Promise<NameMap | null
 }
 
 async function saveCache(workspace: string, key: string, data: NameMap): Promise<void> {
-  const path = join(getCacheDir(), cacheFileName(workspace, key));
+  const dir = getCacheDir();
+  await mkdir(dir, { recursive: true });
+  const path = join(dir, cacheFileName(workspace, key));
   const entry: CacheEntry<NameMap> = {
     data,
     expiresAt: Date.now() + CACHE_TTL,

--- a/tests/resolve.spec.ts
+++ b/tests/resolve.spec.ts
@@ -80,6 +80,16 @@ describe("resolveChannel", () => {
 		expect((client as any).conversations.list).toHaveBeenCalledTimes(2)
 	})
 
+	it("should create cache dir on first save (regression: #28 ENOENT)", async () => {
+		// Simulate fresh install: cache dir does not exist yet
+		await rm(join(tempDir, ".config", "holla", "cache"), { recursive: true })
+
+		const { resolveChannel } = await import("../src/platforms/slack/resolve.ts")
+		const client = mockClient([{ name: "general", id: "C001" }], [])
+		const result = await resolveChannel(client as any, "#general", "ws1")
+		expect(result).toBe("C001")
+	})
+
 	it("should namespace cache by workspace (regression: cross-workspace collision)", async () => {
 		const { resolveChannel } = await import("../src/platforms/slack/resolve.ts")
 		const clientA = mockClient([{ name: "general", id: "C001" }], [])


### PR DESCRIPTION
## **User description**
## Summary
- `resolve.ts:saveCache` now does `mkdir -p` on the cache dir before `writeFile`, so a fresh install (or a user who deleted `~/.config/holla/cache`) doesn't crash on the first `chat send` cache miss.
- Adds a regression test that removes the cache dir between `beforeEach` setup and the resolve call.

Fixes #28.

## Test plan
- [x] `bunx vitest run tests/resolve.spec.ts` — new test fails on `main`, passes with the fix.
- [x] `bunx vitest run` — 367 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where Slack integration cache operations would fail when the cache directory didn't exist on first run, preventing proper channel and user resolution.

* **Tests**
  * Added regression test to validate that cache directory creation functions correctly during initial setup.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/circlesac/holla-cli/pull/30)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Create the Slack cache folder before saving channel lookups**

### What Changed
- Saving a channel or user lookup now creates the cache folder first, so a fresh install or a deleted cache folder no longer causes the first lookup to fail
- Added a regression test that removes the cache folder and confirms channel lookup still works on the first save

### Impact
`✅ Fewer first-run cache errors`
`✅ Fewer broken Slack channel lookups`
`✅ Safer recovery after cache folder deletion`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
