### PR TITLE
feat(auth): --name alias for multiple tokens per team (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ holla slack auth login
 
 # Or paste a token directly
 holla slack auth login --token xoxb-...
+
+# Register multiple tokens against the same team with custom aliases
+holla slack auth login --token xoxp-... --name acme_bot
+holla slack auth login --token xoxp-... --name acme_ops
 ```
 
 ## Commands
@@ -32,9 +36,13 @@ holla slack auth login --token xoxb-...
 ### Auth
 
 ```bash
-holla slack auth login        # OAuth login (default) or --token
-holla slack auth logout       # Remove stored credentials
-holla slack auth status       # Show auth status for all workspaces
+holla slack auth login                       # OAuth login (default)
+holla slack auth login --token xoxp-...      # Login with a pasted token
+holla slack auth login --token xoxp-... --name acme_bot
+                                              # ...with a custom alias so multiple tokens
+                                              # can coexist against the same team
+holla slack auth logout                       # Remove stored credentials
+holla slack auth status                       # Show auth status for all workspaces
 ```
 
 ### Channels

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -17,6 +17,7 @@ export async function storeToken(
   workspace: string,
   tokenType: "bot" | "user",
   token: string,
+  identity?: { teamId?: string; teamName?: string },
 ): Promise<void> {
   await ensureCredentialsDir();
   const existing = await getWorkspaceCredentials(workspace);
@@ -27,6 +28,9 @@ export async function storeToken(
   } else {
     creds.userToken = token;
   }
+
+  if (identity?.teamId) creds.teamId = identity.teamId;
+  if (identity?.teamName) creds.teamName = identity.teamName;
 
   await writeFile(credentialPath(workspace), JSON.stringify(creds, null, 2));
 }

--- a/src/platforms/slack/auth/login.ts
+++ b/src/platforms/slack/auth/login.ts
@@ -12,7 +12,7 @@ const DEFAULT_CLIENT_SECRET = "85212febb6a85d3088045da95297188a";
 const BOT_SCOPES = manifest.oauth_config.scopes.bot.join(",");
 const USER_SCOPES = manifest.oauth_config.scopes.user.join(",");
 
-async function loginWithToken(token: string): Promise<void> {
+async function loginWithToken(token: string, alias?: string): Promise<void> {
   let tokenType: "bot" | "user";
   if (token.startsWith("xoxb-")) {
     tokenType = "bot";
@@ -27,17 +27,19 @@ async function loginWithToken(token: string): Promise<void> {
 
   const client = createSlackClient(token);
   const result = await client.auth.test();
-  const workspace = result.team as string;
-  const teamUrl = result.url as string;
+  const teamName = result.team as string;
+  const teamId = result.team_id as string | undefined;
+  const teamUrl = result.url as string | undefined;
 
-  const workspaceName = teamUrl
+  const derivedName = teamUrl
     ? new URL(teamUrl).hostname.split(".")[0]!
-    : workspace.toLowerCase().replace(/\s+/g, "-");
+    : teamName.toLowerCase().replace(/\s+/g, "-");
+  const workspaceName = alias ?? derivedName;
 
-  await storeToken(workspaceName, tokenType, token);
+  await storeToken(workspaceName, tokenType, token, { teamId, teamName });
 
   console.log(
-    `\x1b[32m✓\x1b[0m Authorized! ${tokenType} token saved for "${workspace}" (${workspaceName})`,
+    `\x1b[32m✓\x1b[0m Authorized! ${tokenType} token saved for "${teamName}" (${workspaceName})`,
   );
 }
 
@@ -48,6 +50,7 @@ function randomPort(): number {
 async function loginWithOAuth(
   clientId: string,
   clientSecret: string,
+  alias?: string,
 ): Promise<void> {
   const port = randomPort();
   const state = btoa(JSON.stringify({ p: port }));
@@ -156,8 +159,8 @@ async function loginWithOAuth(
   const teamName = data.team?.name ?? "unknown";
   const teamId = data.team?.id ?? "";
 
-  // Derive workspace name from team info
-  let workspaceName = teamName.toLowerCase().replace(/\s+/g, "-");
+  // Derive workspace name from team info (unless overridden via --name)
+  let derivedName = teamName.toLowerCase().replace(/\s+/g, "-");
 
   // Try to get the actual subdomain via auth.test
   const botToken = data.access_token;
@@ -167,29 +170,32 @@ async function loginWithOAuth(
       const authResult = await client.auth.test();
       const teamUrl = authResult.url as string | undefined;
       if (teamUrl) {
-        workspaceName = new URL(teamUrl).hostname.split(".")[0]!;
+        derivedName = new URL(teamUrl).hostname.split(".")[0]!;
       }
     } catch {
       // fall back to derived name
     }
   }
 
+  const workspaceName = alias ?? derivedName;
+  const identity = { teamId, teamName };
+
   // Store tokens
   let botSaved = false;
   let userSaved = false;
 
   if (data.access_token) {
-    await storeToken(workspaceName, "bot", data.access_token);
+    await storeToken(workspaceName, "bot", data.access_token, identity);
     botSaved = true;
   }
 
   if (data.authed_user?.access_token) {
-    await storeToken(workspaceName, "user", data.authed_user.access_token);
+    await storeToken(workspaceName, "user", data.authed_user.access_token, identity);
     userSaved = true;
   }
 
   console.log(
-    `\x1b[32m✓\x1b[0m Authorized! Tokens saved for "${teamName}" (${teamId})`,
+    `\x1b[32m✓\x1b[0m Authorized! Tokens saved as "${workspaceName}" for "${teamName}" (${teamId})`,
   );
   console.log(
     `  Bot token:  ${botSaved ? "\x1b[32m✓\x1b[0m" : "\x1b[33m—\x1b[0m not granted"}`,
@@ -206,6 +212,12 @@ export const loginCommand = defineCommand({
       type: "string",
       description: "Slack token (xoxb-... or xoxp-...) for manual auth",
     },
+    name: {
+      type: "string",
+      description:
+        "Custom workspace alias for the credential file (use to register multiple tokens against the same team, e.g. acme_bot vs acme_ops)",
+      alias: "as",
+    },
     "client-id": {
       type: "string",
       description: "Slack app client ID (or set SLACK_CLIENT_ID)",
@@ -218,10 +230,18 @@ export const loginCommand = defineCommand({
   async run({ args }) {
     await ensureConfigDir();
 
+    const alias = args.name?.trim() || undefined;
+    if (alias && !/^[a-zA-Z0-9_-]+$/.test(alias)) {
+      console.error(
+        "\x1b[31m✗\x1b[0m --name must contain only letters, digits, hyphen, or underscore",
+      );
+      process.exit(1);
+    }
+
     // Manual token flow
     if (args.token) {
       try {
-        await loginWithToken(args.token);
+        await loginWithToken(args.token, alias);
       } catch (error) {
         handleError(error);
       }
@@ -235,7 +255,7 @@ export const loginCommand = defineCommand({
       args["client-secret"] ?? process.env["SLACK_CLIENT_SECRET"] ?? DEFAULT_CLIENT_SECRET;
 
     try {
-      await loginWithOAuth(clientId, clientSecret);
+      await loginWithOAuth(clientId, clientSecret, alias);
     } catch (error) {
       handleError(error);
     }

--- a/src/platforms/slack/auth/status.ts
+++ b/src/platforms/slack/auth/status.ts
@@ -25,7 +25,11 @@ export const statusCommand = defineCommand({
     const results = [];
 
     for (const ws of workspaces) {
-      const entry: Record<string, string> = { workspace: ws.name };
+      const entry: Record<string, string> = {
+        workspace: ws.name,
+        team: ws.teamName ?? "—",
+        team_id: ws.teamId ?? "—",
+      };
 
       if (ws.botToken) {
         try {
@@ -64,6 +68,8 @@ export const statusCommand = defineCommand({
 
     printOutput(results, getOutputFormat(args), [
       { key: "workspace", label: "Workspace" },
+      { key: "team", label: "Team" },
+      { key: "team_id", label: "Team ID" },
       { key: "bot", label: "Bot" },
       { key: "user", label: "User" },
     ]);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,6 +12,8 @@ export interface HollaConfig {
 
 export interface WorkspaceCredentials {
   name: string;
+  teamId?: string;
+  teamName?: string;
   botToken?: string;
   userToken?: string;
   browserToken?: string;

--- a/tests/credentials.spec.ts
+++ b/tests/credentials.spec.ts
@@ -118,4 +118,42 @@ describe("credentials", () => {
 		await storeToken("test-ws", "bot", "xoxb-bot")
 		await expect(getToken("test-ws")).rejects.toThrow("No user token found")
 	})
+
+	it("should persist team identity when provided", async () => {
+		const { storeToken, getWorkspaceCredentials } = await import(
+			"../src/lib/credentials.ts"
+		)
+		await storeToken("acme_bot", "bot", "xoxb-1", {
+			teamId: "T0123",
+			teamName: "Acme",
+		})
+		const creds = await getWorkspaceCredentials("acme_bot")
+		expect(creds!.teamId).toBe("T0123")
+		expect(creds!.teamName).toBe("Acme")
+	})
+
+	it("should support two aliases for the same team (regression: #29)", async () => {
+		const { storeToken, listWorkspaces, getWorkspaceCredentials } = await import(
+			"../src/lib/credentials.ts"
+		)
+		await storeToken("acme_bot", "user", "xoxp-bot-app", {
+			teamId: "T0123",
+			teamName: "Acme",
+		})
+		await storeToken("acme_ops", "user", "xoxp-ops-app", {
+			teamId: "T0123",
+			teamName: "Acme",
+		})
+
+		const list = await listWorkspaces()
+		const names = list.map((w) => w.name).sort()
+		expect(names).toStrictEqual(["acme_bot", "acme_ops"])
+
+		const bot = await getWorkspaceCredentials("acme_bot")
+		const ops = await getWorkspaceCredentials("acme_ops")
+		expect(bot!.userToken).toBe("xoxp-bot-app")
+		expect(ops!.userToken).toBe("xoxp-ops-app")
+		expect(bot!.teamId).toBe("T0123")
+		expect(ops!.teamId).toBe("T0123")
+	})
 })


### PR DESCRIPTION
## **User description**
## Summary
- New \`--name <alias>\` flag (alias: \`--as\`) on \`holla slack auth login\` lets users store multiple tokens against the same Slack team under distinct workspace aliases (e.g. \`acme_bot\` vs \`acme_ops\`). Without it, the second login overwrote the first.
- Captures \`team_id\` + \`teamName\` on login (manual + OAuth paths) and persists them on the credential file.
- \`auth status\` now shows Team / Team ID columns so it's obvious which credential maps to which team when aliases are in play.
- README updated with the new flag.

Fixes #29.

## Test plan
- [x] \`bunx vitest run\` — 368 pass (2 new tests cover identity persistence and the two-alias-same-team scenario).
- [x] \`bun run src/index.ts slack auth login --help\` shows the new \`--name\` flag.
- [ ] Manual: \`holla slack auth login --token xoxp-... --name foo_bot\` then \`holla slack auth login --token xoxp-... --name foo_ops\` — both should appear in \`auth status\` with the same Team ID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Name Slack logins to keep multiple tokens for the same team**

### What Changed
- You can now save Slack logins under a custom alias, so multiple tokens for the same team no longer overwrite each other
- Login checks the alias for invalid characters and stops with a clear error if the name is not valid
- Auth status now shows the saved team name and team ID for each workspace
- Saved credentials now keep the Slack team name and team ID, and the setup docs include the new alias option

### Impact
`✅ Multiple Slack tokens per team`
`✅ Fewer overwritten logins`
`✅ Clearer auth status for shared teams`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
