### PR TITLE
feat(cache): shared cache module + incremental history append (#24)

### DIFF
--- a/src/lib/args.ts
+++ b/src/lib/args.ts
@@ -6,6 +6,10 @@ export const commonArgs = {
   },
   json: { type: "boolean" as const, description: "Output as JSON" },
   plain: { type: "boolean" as const, description: "Output as plain text" },
+  "no-cache": {
+    type: "boolean" as const,
+    description: "Bypass local cache and fetch fresh data",
+  },
 };
 
 export const cursorPaginationArgs = {

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,0 +1,135 @@
+import { join } from "node:path";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { getCacheDir } from "./config.ts";
+
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000; // 1 day
+
+export interface ListCacheEntry<T> {
+  updatedAt: number;
+  data: T[];
+}
+
+export interface HistoryCacheEntry {
+  updatedAt: number;
+  newestTs: string;
+  messages: Record<string, unknown>[];
+}
+
+function cachePath(workspace: string, key: string): string {
+  return join(getCacheDir(), `${workspace}-${key}.json`);
+}
+
+async function readJSON<T>(path: string): Promise<T | null> {
+  try {
+    const content = await readFile(path, "utf-8");
+    return JSON.parse(content) as T;
+  } catch {
+    return null;
+  }
+}
+
+async function writeJSON(path: string, value: unknown): Promise<void> {
+  await mkdir(getCacheDir(), { recursive: true });
+  await writeFile(path, JSON.stringify(value));
+}
+
+export function shouldBypassCache(args: Record<string, unknown>): boolean {
+  return Boolean(args["no-cache"]);
+}
+
+export function isFresh(entry: { updatedAt: number }, ttlMs = DEFAULT_TTL_MS): boolean {
+  return Date.now() - entry.updatedAt < ttlMs;
+}
+
+export async function loadListCache<T>(
+  workspace: string,
+  key: string,
+): Promise<ListCacheEntry<T> | null> {
+  const path = cachePath(workspace, key);
+  const entry = await readJSON<ListCacheEntry<T>>(path);
+  if (!entry || typeof entry.updatedAt !== "number" || !Array.isArray(entry.data)) {
+    return null;
+  }
+  return entry;
+}
+
+export async function saveListCache<T>(
+  workspace: string,
+  key: string,
+  data: T[],
+): Promise<void> {
+  const entry: ListCacheEntry<T> = { updatedAt: Date.now(), data };
+  await writeJSON(cachePath(workspace, key), entry);
+}
+
+/**
+ * Stale-while-revalidate for full-list resources (users list, channels list, channels members).
+ *
+ * - Fresh cache → return cached data without calling the fetcher.
+ * - Stale cache → call fetcher, replace cache, return fresh data. The stale entry is
+ *   only thrown away after a successful fetch, so cold-start cost is paid once.
+ * - bypass=true forces the fetcher and refreshes the cache.
+ */
+export async function revalidateList<T>(
+  workspace: string,
+  key: string,
+  fetcher: () => Promise<T[]>,
+  options: { bypass?: boolean; ttlMs?: number } = {},
+): Promise<T[]> {
+  const ttl = options.ttlMs ?? DEFAULT_TTL_MS;
+  if (!options.bypass) {
+    const entry = await loadListCache<T>(workspace, key);
+    if (entry && isFresh(entry, ttl)) return entry.data;
+  }
+  const data = await fetcher();
+  await saveListCache(workspace, key, data);
+  return data;
+}
+
+export async function loadHistoryCache(
+  workspace: string,
+  channelId: string,
+): Promise<HistoryCacheEntry | null> {
+  const path = cachePath(workspace, `history-${channelId}`);
+  const entry = await readJSON<HistoryCacheEntry>(path);
+  if (
+    !entry ||
+    typeof entry.updatedAt !== "number" ||
+    typeof entry.newestTs !== "string" ||
+    !Array.isArray(entry.messages)
+  ) {
+    return null;
+  }
+  return entry;
+}
+
+export async function saveHistoryCache(
+  workspace: string,
+  channelId: string,
+  messages: Record<string, unknown>[],
+  newestTs: string,
+): Promise<void> {
+  const entry: HistoryCacheEntry = { updatedAt: Date.now(), newestTs, messages };
+  await writeJSON(cachePath(workspace, `history-${channelId}`), entry);
+}
+
+export function pickNewestTs(messages: Record<string, unknown>[], fallback = ""): string {
+  let newest = fallback;
+  for (const msg of messages) {
+    const ts = typeof msg.ts === "string" ? msg.ts : "";
+    if (ts && (newest === "" || compareTs(ts, newest) > 0)) {
+      newest = ts;
+    }
+  }
+  return newest;
+}
+
+// Slack timestamps look like "1719876543.123456" — string compare works because
+// the integer-seconds segment has a fixed length on the relevant time horizon.
+// Use numeric compare to be defensive against any weird padding.
+export function compareTs(a: string, b: string): number {
+  const av = parseFloat(a);
+  const bv = parseFloat(b);
+  if (Number.isNaN(av) || Number.isNaN(bv)) return a.localeCompare(b);
+  return av - bv;
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -3,26 +3,29 @@ import { homedir } from "node:os";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import type { HollaConfig } from "../types/index.ts";
 
-const CONFIG_DIR = join(homedir(), ".config", "holla");
-const CONFIG_FILE = join(CONFIG_DIR, "config.json");
-const CACHE_DIR = join(CONFIG_DIR, "cache");
-
+// Resolve paths lazily so tests that stub HOME via vi.stubEnv between imports
+// see the override. (Module-level constants captured homedir() at import time
+// and ignored test-time overrides.)
 export function getConfigDir(): string {
-  return CONFIG_DIR;
+  return join(homedir(), ".config", "holla");
 }
 
 export function getCacheDir(): string {
-  return CACHE_DIR;
+  return join(getConfigDir(), "cache");
+}
+
+function getConfigFile(): string {
+  return join(getConfigDir(), "config.json");
 }
 
 export async function ensureConfigDir(): Promise<void> {
-  await mkdir(CONFIG_DIR, { recursive: true });
-  await mkdir(CACHE_DIR, { recursive: true });
+  await mkdir(getConfigDir(), { recursive: true });
+  await mkdir(getCacheDir(), { recursive: true });
 }
 
 export async function readConfig(): Promise<HollaConfig> {
   try {
-    const content = await readFile(CONFIG_FILE, "utf-8");
+    const content = await readFile(getConfigFile(), "utf-8");
     return JSON.parse(content) as HollaConfig;
   } catch {
     return {};
@@ -31,5 +34,5 @@ export async function readConfig(): Promise<HollaConfig> {
 
 export async function writeConfig(config: HollaConfig): Promise<void> {
   await ensureConfigDir();
-  await writeFile(CONFIG_FILE, JSON.stringify(config, null, 2) + "\n");
+  await writeFile(getConfigFile(), JSON.stringify(config, null, 2) + "\n");
 }

--- a/src/platforms/slack/channels/history.ts
+++ b/src/platforms/slack/channels/history.ts
@@ -9,6 +9,13 @@ import {
   rateLimitRetry,
   RateLimitTimeoutError,
 } from "../../../lib/rate-limit.ts";
+import {
+  loadHistoryCache,
+  saveHistoryCache,
+  shouldBypassCache,
+  compareTs,
+  pickNewestTs,
+} from "../../../lib/cache.ts";
 
 export const historyCommand = defineCommand({
   meta: { name: "history", description: "Fetch channel message history" },
@@ -45,6 +52,20 @@ export const historyCommand = defineCommand({
       let cursor: string | undefined = args.cursor;
       let partial = false;
 
+      // Incremental cache only kicks in for `--all` channel history without
+      // explicit time bounds. Threads / bounded queries always hit the API.
+      const useHistoryCache =
+        !args.thread &&
+        Boolean(args.all) &&
+        !args.before &&
+        !args.after &&
+        !args.cursor &&
+        !shouldBypassCache(args as Record<string, unknown>);
+
+      const cachedHistory = useHistoryCache
+        ? await loadHistoryCache(workspace, channelId)
+        : null;
+
       try {
         if (args.thread) {
           do {
@@ -77,6 +98,10 @@ export const historyCommand = defineCommand({
             cursor = result.response_metadata?.next_cursor || undefined;
           } while (args.all && cursor);
         } else {
+          // If we have a cache, fetch only messages newer than the cached newest ts.
+          // Note: edits/deletes on cached messages are not reflected (append-only,
+          // by design — issue #24 trade-off).
+          const oldest = cachedHistory?.newestTs || args.after;
           do {
             const result = await rateLimitRetry(() =>
               client.conversations.history({
@@ -84,7 +109,7 @@ export const historyCommand = defineCommand({
                 ...(limit !== undefined ? { limit } : {}),
                 cursor,
                 latest: args.before,
-                oldest: args.after,
+                oldest,
               }),
             );
 
@@ -123,7 +148,25 @@ export const historyCommand = defineCommand({
         process.exitCode = 1;
       }
 
-      printOutput(messages, getOutputFormat(args), [
+      // Merge cached + fresh, persist, return.
+      // `messages` already came back newest-first from the API; the cached
+      // entries are older, so they go at the end of the timeline.
+      let combined = messages;
+      if (useHistoryCache) {
+        const cachedMessages = cachedHistory?.messages ?? [];
+        combined = [...messages, ...cachedMessages];
+        if (!partial) {
+          const prevNewest = cachedHistory?.newestTs ?? "";
+          const fetchedNewest = pickNewestTs(messages, prevNewest);
+          const newestTs =
+            compareTs(fetchedNewest, prevNewest) >= 0 ? fetchedNewest : prevNewest;
+          if (newestTs) {
+            await saveHistoryCache(workspace, channelId, combined, newestTs);
+          }
+        }
+      }
+
+      printOutput(combined, getOutputFormat(args), [
         { key: "ts", label: "Timestamp" },
         { key: "user", label: "User" },
         { key: "text", label: "Text" },

--- a/src/platforms/slack/channels/list.ts
+++ b/src/platforms/slack/channels/list.ts
@@ -4,6 +4,10 @@ import { createSlackClient } from "../client.ts";
 import { printOutput, getOutputFormat } from "../../../lib/output.ts";
 import { handleError } from "../../../lib/errors.ts";
 import { commonArgs, cursorPaginationArgs } from "../../../lib/args.ts";
+import { shouldBypassCache } from "../../../lib/cache.ts";
+import { fetchAllChannels } from "../lists.ts";
+
+const DEFAULT_TYPES = "public_channel,private_channel";
 
 export const listCommand = defineCommand({
   meta: { name: "list", description: "List channels" },
@@ -22,36 +26,55 @@ export const listCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      const { token } = await getToken(args.workspace);
+      const { token, workspace } = await getToken(args.workspace);
       const client = createSlackClient(token);
 
-      const limit = args.limit ? parseInt(args.limit, 10) : undefined;
-      const types = args.types ?? "public_channel,private_channel";
-
       const nameFilter = args.name ? args.name.toLowerCase() : undefined;
+      const customTypes = args.types && args.types !== DEFAULT_TYPES;
+      const customPagination = Boolean(args.cursor) || Boolean(args.limit);
+      // The shared cache only stores the canonical channel set (public+private,
+      // non-archived). Only use it when the user is asking for the full set
+      // (--all) without custom filters.
+      const canUseCache = Boolean(args.all) && !customTypes && !customPagination;
+
       const channels: Record<string, unknown>[] = [];
-      let cursor: string | undefined = args.cursor;
 
-      do {
-        const result = await client.conversations.list({
-          ...(limit !== undefined ? { limit } : {}),
-          types,
-          cursor,
+      if (canUseCache) {
+        const records = await fetchAllChannels(client, workspace, {
+          bypass: shouldBypassCache(args as Record<string, unknown>),
         });
-
-        for (const ch of result.channels ?? []) {
-          const chName = ch.name ?? "";
-          if (nameFilter && !chName.toLowerCase().includes(nameFilter)) continue;
+        for (const r of records) {
+          if (nameFilter && !r.name.toLowerCase().includes(nameFilter)) continue;
           channels.push({
-            id: ch.id ?? "",
-            name: chName,
-            topic: (ch.topic as { value?: string })?.value ?? "",
-            num_members: ch.num_members ?? 0,
+            id: r.id,
+            name: r.name,
+            topic: r.topic_value ?? "",
+            num_members: r.num_members ?? 0,
           });
         }
-
-        cursor = result.response_metadata?.next_cursor || undefined;
-      } while (args.all && cursor);
+      } else {
+        const limit = args.limit ? parseInt(args.limit, 10) : undefined;
+        const types = args.types ?? DEFAULT_TYPES;
+        let cursor: string | undefined = args.cursor;
+        do {
+          const result = await client.conversations.list({
+            ...(limit !== undefined ? { limit } : {}),
+            types,
+            cursor,
+          });
+          for (const ch of result.channels ?? []) {
+            const chName = ch.name ?? "";
+            if (nameFilter && !chName.toLowerCase().includes(nameFilter)) continue;
+            channels.push({
+              id: ch.id ?? "",
+              name: chName,
+              topic: (ch.topic as { value?: string })?.value ?? "",
+              num_members: ch.num_members ?? 0,
+            });
+          }
+          cursor = result.response_metadata?.next_cursor || undefined;
+        } while (args.all && cursor);
+      }
 
       printOutput(channels, getOutputFormat(args), [
         { key: "id", label: "ID" },

--- a/src/platforms/slack/channels/members.ts
+++ b/src/platforms/slack/channels/members.ts
@@ -5,6 +5,8 @@ import { resolveChannel } from "../resolve.ts";
 import { printOutput, getOutputFormat } from "../../../lib/output.ts";
 import { handleError } from "../../../lib/errors.ts";
 import { commonArgs, cursorPaginationArgs } from "../../../lib/args.ts";
+import { revalidateList, shouldBypassCache } from "../../../lib/cache.ts";
+import { rateLimitRetry } from "../../../lib/rate-limit.ts";
 
 export const membersCommand = defineCommand({
   meta: { name: "members", description: "List channel members" },
@@ -23,24 +25,47 @@ export const membersCommand = defineCommand({
       const client = createSlackClient(token);
       const channelId = await resolveChannel(client, args.channel, workspace);
 
-      const limit = args.limit ? parseInt(args.limit, 10) : undefined;
+      const customPagination = Boolean(args.cursor) || Boolean(args.limit);
+      const canUseCache = Boolean(args.all) && !customPagination;
 
-      const memberIds: string[] = [];
-      let cursor: string | undefined = args.cursor;
+      let memberIds: string[];
 
-      do {
-        const result = await client.conversations.members({
-          channel: channelId,
-          limit,
-          cursor,
-        });
-
-        for (const id of result.members ?? []) {
-          memberIds.push(id);
-        }
-
-        cursor = result.response_metadata?.next_cursor || undefined;
-      } while (args.all && cursor);
+      if (canUseCache) {
+        memberIds = await revalidateList<string>(
+          workspace,
+          `members-${channelId}`,
+          async () => {
+            const ids: string[] = [];
+            let cursor: string | undefined;
+            do {
+              const result = await rateLimitRetry(() =>
+                client.conversations.members({
+                  channel: channelId,
+                  limit: 1000,
+                  cursor,
+                }),
+              );
+              for (const id of result.members ?? []) ids.push(id);
+              cursor = result.response_metadata?.next_cursor || undefined;
+            } while (cursor);
+            return ids;
+          },
+          { bypass: shouldBypassCache(args as Record<string, unknown>) },
+        );
+      } else {
+        const limit = args.limit ? parseInt(args.limit, 10) : undefined;
+        memberIds = [];
+        let cursor: string | undefined = args.cursor;
+        do {
+          const result = await client.conversations.members({
+            channel: channelId,
+            limit,
+            cursor,
+          });
+          for (const id of result.members ?? []) memberIds.push(id);
+          cursor = result.response_metadata?.next_cursor || undefined;
+        } while (args.all && cursor);
+      }
 
       const members = memberIds.map((id) => ({ id }));
 

--- a/src/platforms/slack/lists.ts
+++ b/src/platforms/slack/lists.ts
@@ -1,0 +1,91 @@
+import type { WebClient } from "@slack/web-api";
+import { revalidateList } from "../../lib/cache.ts";
+import { rateLimitRetry } from "../../lib/rate-limit.ts";
+
+export interface ChannelRecord {
+  id: string;
+  name: string;
+  is_archived?: boolean;
+  num_members?: number;
+  topic_value?: string;
+}
+
+export interface UserRecord {
+  id: string;
+  name: string;
+  real_name?: string;
+  display_name?: string;
+  deleted?: boolean;
+}
+
+export async function fetchAllChannels(
+  client: WebClient,
+  workspace: string,
+  options: { bypass?: boolean } = {},
+): Promise<ChannelRecord[]> {
+  return revalidateList<ChannelRecord>(
+    workspace,
+    "channels",
+    async () => {
+      const records: ChannelRecord[] = [];
+      let cursor: string | undefined;
+      do {
+        const result = await rateLimitRetry(() =>
+          client.conversations.list({
+            limit: 1000,
+            types: "public_channel,private_channel",
+            cursor,
+            exclude_archived: true,
+          }),
+        );
+        for (const ch of result.channels ?? []) {
+          if (!ch.id) continue;
+          records.push({
+            id: ch.id,
+            name: ch.name ?? "",
+            is_archived: ch.is_archived ?? false,
+            num_members: ch.num_members ?? 0,
+            topic_value: (ch.topic as { value?: string } | undefined)?.value ?? "",
+          });
+        }
+        cursor = result.response_metadata?.next_cursor || undefined;
+      } while (cursor);
+      return records;
+    },
+    options,
+  );
+}
+
+export async function fetchAllUsers(
+  client: WebClient,
+  workspace: string,
+  options: { bypass?: boolean } = {},
+): Promise<UserRecord[]> {
+  return revalidateList<UserRecord>(
+    workspace,
+    "users",
+    async () => {
+      const records: UserRecord[] = [];
+      let cursor: string | undefined;
+      do {
+        const result = await rateLimitRetry(() =>
+          client.users.list({ limit: 1000, cursor }),
+        );
+        for (const user of result.members ?? []) {
+          if (!user.id) continue;
+          records.push({
+            id: user.id,
+            name: user.name ?? "",
+            real_name: user.real_name ?? "",
+            display_name:
+              (user.profile as { display_name?: string } | undefined)?.display_name ?? "",
+            deleted: user.deleted ?? false,
+          });
+        }
+        cursor = result.response_metadata?.next_cursor || undefined;
+      } while (cursor);
+      return records;
+    },
+    options,
+  );
+}

--- a/src/platforms/slack/resolve.ts
+++ b/src/platforms/slack/resolve.ts
@@ -1,11 +1,7 @@
-import { join } from "node:path";
-import { readFile, writeFile, mkdir } from "node:fs/promises";
-import { getCacheDir } from "../../lib/config.ts";
 import type { WebClient } from "@slack/web-api";
-import type { CacheEntry } from "../../types/index.ts";
+import { fetchAllChannels, fetchAllUsers } from "./lists.ts";
 import { rateLimitRetry } from "../../lib/rate-limit.ts";
 
-const CACHE_TTL = 24 * 60 * 60 * 1000; // 1 day
 const MAX_SUGGESTIONS = 3;
 
 function levenshtein(a: string, b: string): number {
@@ -33,93 +29,6 @@ function suggest(input: string, candidates: string[]): string {
   return `\n  Did you mean: ${scored.map((s) => s.name).join(", ")}?`;
 }
 
-interface NameMap {
-  [name: string]: string;
-}
-
-function cacheFileName(workspace: string, key: string): string {
-  return `${workspace}-${key}.json`;
-}
-
-async function loadCache(workspace: string, key: string): Promise<NameMap | null> {
-  try {
-    const path = join(getCacheDir(), cacheFileName(workspace, key));
-    const content = await readFile(path, "utf-8");
-    const entry = JSON.parse(content) as CacheEntry<NameMap>;
-    if (Date.now() > entry.expiresAt) return null;
-    return entry.data;
-  } catch {
-    return null;
-  }
-}
-
-async function saveCache(workspace: string, key: string, data: NameMap): Promise<void> {
-  const dir = getCacheDir();
-  await mkdir(dir, { recursive: true });
-  const path = join(dir, cacheFileName(workspace, key));
-  const entry: CacheEntry<NameMap> = {
-    data,
-    expiresAt: Date.now() + CACHE_TTL,
-  };
-  await writeFile(path, JSON.stringify(entry));
-}
-
-async function fetchChannelMap(client: WebClient, workspace: string): Promise<NameMap> {
-  const cached = await loadCache(workspace, "channels");
-  if (cached) return cached;
-
-  const map: NameMap = {};
-  let cursor: string | undefined;
-
-  do {
-    const result = await rateLimitRetry(() =>
-      client.conversations.list({
-        limit: 1000,
-        types: "public_channel,private_channel",
-        cursor,
-        exclude_archived: true,
-      }),
-    );
-    for (const ch of result.channels ?? []) {
-      if (ch.name && ch.id) {
-        map[ch.name] = ch.id;
-      }
-    }
-    cursor = result.response_metadata?.next_cursor || undefined;
-  } while (cursor);
-
-  await saveCache(workspace, "channels", map);
-  return map;
-}
-
-async function findChannelIdByName(client: WebClient, workspace: string, name: string): Promise<string | undefined> {
-  const map = await fetchChannelMap(client, workspace);
-  return map[name];
-}
-
-async function fetchUserMap(client: WebClient, workspace: string): Promise<NameMap> {
-  const cached = await loadCache(workspace, "users");
-  if (cached) return cached;
-
-  const map: NameMap = {};
-  let cursor: string | undefined;
-
-  do {
-    const result = await rateLimitRetry(() =>
-      client.users.list({ limit: 1000, cursor }),
-    );
-    for (const user of result.members ?? []) {
-      if (user.name && user.id) {
-        map[user.name] = user.id;
-      }
-    }
-    cursor = result.response_metadata?.next_cursor || undefined;
-  } while (cursor);
-
-  await saveCache(workspace, "users", map);
-  return map;
-}
-
 export async function resolveChannel(
   client: WebClient,
   input: string,
@@ -127,10 +36,11 @@ export async function resolveChannel(
 ): Promise<string> {
   if (!input.startsWith("#")) return input;
   const name = input.slice(1);
-  const id = await findChannelIdByName(client, workspace, name);
+  const records = await fetchAllChannels(client, workspace);
+  const map: Record<string, string> = {};
+  for (const r of records) if (r.name) map[r.name] = r.id;
+  const id = map[name];
   if (id) return id;
-  // Not found — fetch full map for suggestions
-  const map = await fetchChannelMap(client, workspace);
   throw new Error(`Channel not found: ${input}${suggest(name, Object.keys(map))}`);
 }
 
@@ -141,7 +51,9 @@ export async function resolveUser(
 ): Promise<string> {
   if (!input.startsWith("@")) return input;
   const name = input.slice(1);
-  const map = await fetchUserMap(client, workspace);
+  const records = await fetchAllUsers(client, workspace);
+  const map: Record<string, string> = {};
+  for (const r of records) if (r.name) map[r.name] = r.id;
   const id = map[name];
   if (!id) throw new Error(`User not found: ${input}${suggest(name, Object.keys(map))}`);
   return id;
@@ -152,10 +64,8 @@ export async function resolveUserName(
   userId: string,
   workspace: string,
 ): Promise<string> {
-  const map = await fetchUserMap(client, workspace);
-  for (const [name, id] of Object.entries(map)) {
-    if (id === userId) return name;
-  }
+  const records = await fetchAllUsers(client, workspace);
+  for (const r of records) if (r.id === userId) return r.name || userId;
   return userId;
 }
 

--- a/src/platforms/slack/users/list.ts
+++ b/src/platforms/slack/users/list.ts
@@ -4,6 +4,8 @@ import { createSlackClient } from "../client.ts";
 import { printOutput, getOutputFormat } from "../../../lib/output.ts";
 import { handleError } from "../../../lib/errors.ts";
 import { commonArgs } from "../../../lib/args.ts";
+import { shouldBypassCache } from "../../../lib/cache.ts";
+import { fetchAllUsers } from "../lists.ts";
 
 export const listCommand = defineCommand({
   meta: { name: "list", description: "List users" },
@@ -20,31 +22,41 @@ export const listCommand = defineCommand({
   },
   async run({ args }) {
     try {
-      const { token } = await getToken(args.workspace);
+      const { token, workspace } = await getToken(args.workspace);
       const client = createSlackClient(token);
 
-      const limit = args.limit ? parseInt(args.limit as string, 10) : 1000;
+      const customPagination = Boolean(args.cursor) || Boolean(args.limit);
       const users: Record<string, unknown>[] = [];
-      let cursor: string | undefined = args.cursor;
 
-      do {
-        const result = await client.users.list({
-          limit,
-          cursor,
+      if (!customPagination) {
+        const records = await fetchAllUsers(client, workspace, {
+          bypass: shouldBypassCache(args as Record<string, unknown>),
         });
-
-        for (const user of result.members ?? []) {
+        for (const r of records) {
           users.push({
-            id: user.id ?? "",
-            name: user.name ?? "",
-            real_name: user.real_name ?? "",
-            display_name:
-              (user.profile as { display_name?: string })?.display_name ?? "",
+            id: r.id,
+            name: r.name,
+            real_name: r.real_name ?? "",
+            display_name: r.display_name ?? "",
           });
         }
-
-        cursor = result.response_metadata?.next_cursor || undefined;
-      } while (cursor);
+      } else {
+        const limit = args.limit ? parseInt(args.limit as string, 10) : 1000;
+        let cursor: string | undefined = args.cursor;
+        do {
+          const result = await client.users.list({ limit, cursor });
+          for (const user of result.members ?? []) {
+            users.push({
+              id: user.id ?? "",
+              name: user.name ?? "",
+              real_name: user.real_name ?? "",
+              display_name:
+                (user.profile as { display_name?: string })?.display_name ?? "",
+            });
+          }
+          cursor = result.response_metadata?.next_cursor || undefined;
+        } while (cursor);
+      }
 
       printOutput(users, getOutputFormat(args), [
         { key: "id", label: "ID" },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,8 +25,3 @@ export interface ResolvedEntity {
   name: string;
   resolvedAt: number;
 }
-
-export interface CacheEntry<T> {
-  data: T;
-  expiresAt: number;
-}

--- a/tests/cache.spec.ts
+++ b/tests/cache.spec.ts
@@ -1,0 +1,129 @@
+import { join } from "node:path"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { vi, beforeEach, afterEach } from "vitest"
+
+let tempDir: string
+
+beforeEach(async () => {
+	vi.resetModules()
+	tempDir = await mkdtemp(join(tmpdir(), "holla-cache-test-"))
+	vi.stubEnv("HOME", tempDir)
+})
+
+afterEach(async () => {
+	vi.unstubAllEnvs()
+	await rm(tempDir, { recursive: true, force: true })
+})
+
+describe("revalidateList", () => {
+	it("calls the fetcher when cache is empty and persists the result", async () => {
+		const { revalidateList, loadListCache } = await import("../src/lib/cache.ts")
+		const fetcher = vi.fn().mockResolvedValue([{ id: "A", name: "alpha" }])
+
+		const data = await revalidateList("ws", "channels", fetcher)
+		expect(fetcher).toHaveBeenCalledTimes(1)
+		expect(data).toEqual([{ id: "A", name: "alpha" }])
+
+		const cached = await loadListCache("ws", "channels")
+		expect(cached?.data).toEqual([{ id: "A", name: "alpha" }])
+		expect(typeof cached?.updatedAt).toBe("number")
+	})
+
+	it("returns cached data without calling the fetcher within TTL", async () => {
+		const { revalidateList } = await import("../src/lib/cache.ts")
+		const fetcher = vi.fn().mockResolvedValue([{ id: "A" }])
+		await revalidateList("ws", "channels", fetcher)
+
+		const refetched = vi.fn().mockResolvedValue([{ id: "WRONG" }])
+		const data = await revalidateList("ws", "channels", refetched)
+		expect(refetched).not.toHaveBeenCalled()
+		expect(data).toEqual([{ id: "A" }])
+	})
+
+	it("bypasses the cache when bypass: true", async () => {
+		const { revalidateList } = await import("../src/lib/cache.ts")
+		await revalidateList("ws", "channels", () => Promise.resolve([{ id: "old" }]))
+
+		const fetcher = vi.fn().mockResolvedValue([{ id: "new" }])
+		const data = await revalidateList("ws", "channels", fetcher, { bypass: true })
+		expect(fetcher).toHaveBeenCalledTimes(1)
+		expect(data).toEqual([{ id: "new" }])
+	})
+
+	it("refetches when the cache is older than ttlMs", async () => {
+		const { revalidateList, saveListCache } = await import("../src/lib/cache.ts")
+		await saveListCache("ws", "channels", [{ id: "stale" }])
+		// Backdate the cache by writing manually with old updatedAt
+		const { writeFile } = await import("node:fs/promises")
+		const { join: pjoin } = await import("node:path")
+		await writeFile(
+			pjoin(tempDir, ".config", "holla", "cache", "ws-channels.json"),
+			JSON.stringify({ updatedAt: Date.now() - 10_000, data: [{ id: "stale" }] }),
+		)
+
+		const fetcher = vi.fn().mockResolvedValue([{ id: "fresh" }])
+		const data = await revalidateList("ws", "channels", fetcher, { ttlMs: 1_000 })
+		expect(fetcher).toHaveBeenCalledTimes(1)
+		expect(data).toEqual([{ id: "fresh" }])
+	})
+
+	it("ignores legacy { data, expiresAt } cache format", async () => {
+		const { revalidateList } = await import("../src/lib/cache.ts")
+		const { writeFile, mkdir } = await import("node:fs/promises")
+		const { join: pjoin } = await import("node:path")
+		const dir = pjoin(tempDir, ".config", "holla", "cache")
+		await mkdir(dir, { recursive: true })
+		// Pre-existing v1 cache shape (the resolve.ts pre-#24 format)
+		await writeFile(
+			pjoin(dir, "ws-channels.json"),
+			JSON.stringify({ data: { general: "C001" }, expiresAt: Date.now() + 999_999 }),
+		)
+
+		const fetcher = vi.fn().mockResolvedValue([{ id: "fresh" }])
+		const data = await revalidateList("ws", "channels", fetcher)
+		expect(fetcher).toHaveBeenCalledTimes(1)
+		expect(data).toEqual([{ id: "fresh" }])
+	})
+})
+
+describe("history cache", () => {
+	it("round-trips messages and newestTs", async () => {
+		const { saveHistoryCache, loadHistoryCache } = await import(
+			"../src/lib/cache.ts"
+		)
+		const messages = [
+			{ ts: "200.0", text: "b" },
+			{ ts: "100.0", text: "a" },
+		]
+		await saveHistoryCache("ws", "C001", messages, "200.0")
+		const entry = await loadHistoryCache("ws", "C001")
+		expect(entry?.messages).toEqual(messages)
+		expect(entry?.newestTs).toBe("200.0")
+	})
+
+	it("returns null when cache is missing or shape is wrong", async () => {
+		const { loadHistoryCache } = await import("../src/lib/cache.ts")
+		expect(await loadHistoryCache("ws", "missing")).toBeNull()
+	})
+
+	it("pickNewestTs picks the largest ts numerically", async () => {
+		const { pickNewestTs } = await import("../src/lib/cache.ts")
+		const msgs = [
+			{ ts: "1700000000.000001" },
+			{ ts: "1700000005.123456" },
+			{ ts: "1700000001.999999" },
+		]
+		expect(pickNewestTs(msgs)).toBe("1700000005.123456")
+		expect(pickNewestTs([], "fallback")).toBe("fallback")
+	})
+})
+
+describe("shouldBypassCache", () => {
+	it("is true when --no-cache is set", async () => {
+		const { shouldBypassCache } = await import("../src/lib/cache.ts")
+		expect(shouldBypassCache({ "no-cache": true })).toBe(true)
+		expect(shouldBypassCache({ "no-cache": false })).toBe(false)
+		expect(shouldBypassCache({})).toBe(false)
+	})
+})

--- a/tests/pagination.spec.ts
+++ b/tests/pagination.spec.ts
@@ -1,4 +1,9 @@
+import { join } from "node:path"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
 import { vi, beforeEach } from "vitest"
+
+let tempDir: string
 
 // --- mocks ---
 
@@ -35,14 +40,19 @@ vi.mock("../src/platforms/slack/resolve.ts", () => ({
 	resolveUser: vi.fn().mockResolvedValue("U001"),
 }))
 
-beforeEach(() => {
+beforeEach(async () => {
 	vi.clearAllMocks()
 	vi.spyOn(console, "log").mockImplementation(() => {})
 	vi.spyOn(console, "error").mockImplementation(() => {})
+	// Isolate cache writes per test so the shared cache file doesn't leak across runs.
+	tempDir = await mkdtemp(join(tmpdir(), "holla-pagination-test-"))
+	vi.stubEnv("HOME", tempDir)
 })
 
-afterEach(() => {
+afterEach(async () => {
 	vi.restoreAllMocks()
+	vi.unstubAllEnvs()
+	await rm(tempDir, { recursive: true, force: true })
 })
 
 // ──────────────────────────────────────────────
@@ -178,6 +188,50 @@ describe("channels history", () => {
 		await run({ before: "1700000000.000000" })
 		expect(mockConversationsHistory).toHaveBeenCalledWith(
 			expect.objectContaining({ latest: "1700000000.000000" }),
+		)
+	})
+
+	it("--all with cache: fetches only newer than the cached newestTs and appends (#24)", async () => {
+		// First run: populate cache
+		mockConversationsHistory.mockResolvedValueOnce({
+			messages: [
+				{ ts: "100.0", user: "U1", text: "old1" },
+				{ ts: "50.0", user: "U1", text: "old0" },
+			],
+			response_metadata: { next_cursor: "" },
+		})
+		await run({ all: true })
+
+		// Second run: should pass oldest=100.0 to fetch only newer
+		mockConversationsHistory.mockResolvedValueOnce({
+			messages: [{ ts: "200.0", user: "U2", text: "new1" }],
+			response_metadata: { next_cursor: "" },
+		})
+		await run({ all: true, json: true })
+
+		expect(mockConversationsHistory).toHaveBeenNthCalledWith(2,
+			expect.objectContaining({ oldest: "100.0" }),
+		)
+		const output = (console.log as any).mock.calls.at(-1)[0]
+		const parsed = JSON.parse(output)
+		expect(parsed.map((m: { ts: string }) => m.ts)).toEqual(["200.0", "100.0", "50.0"])
+	})
+
+	it("--all with --no-cache: ignores cache and refetches everything (#24)", async () => {
+		mockConversationsHistory.mockResolvedValueOnce({
+			messages: [{ ts: "100.0", user: "U1", text: "first" }],
+			response_metadata: { next_cursor: "" },
+		})
+		await run({ all: true })
+
+		mockConversationsHistory.mockResolvedValueOnce({
+			messages: [{ ts: "300.0", user: "U2", text: "new" }],
+			response_metadata: { next_cursor: "" },
+		})
+		await run({ all: true, "no-cache": true })
+
+		expect(mockConversationsHistory).toHaveBeenNthCalledWith(2,
+			expect.not.objectContaining({ oldest: expect.anything() }),
 		)
 	})
 })


### PR DESCRIPTION
## **User description**
## Summary
- New \`src/lib/cache.ts\` consolidates cache I/O behind a small API: \`revalidateList\` (stale-while-revalidate), \`loadHistoryCache\` / \`saveHistoryCache\` (per-channel log), and \`shouldBypassCache\` for the new \`--no-cache\` flag. Stores \`updatedAt\` instead of pre-baked \`expiresAt\`.
- New \`src/platforms/slack/lists.ts\` exposes \`fetchAllChannels\` / \`fetchAllUsers\` — both \`channels list\` / \`users list\` commands AND \`resolve.ts\` share the same canonical channels/users cache files.
- \`channels members --all\` caches per-channel member IDs.
- \`channels history --all\` does an incremental append: subsequent runs pass \`oldest=cachedNewestTs\`, fetch only new messages, and prepend them to the stored log. Bounded queries (\`--before\`/\`--after\`/\`--cursor\`) and threads always hit the API.
- \`--no-cache\` is added to \`commonArgs\` so any cached command can opt out per invocation.
- \`getCacheDir()\` / \`getConfigDir()\` are resolved lazily so test \`HOME\` stubs take effect between imports.

Fixes #24.

## Trade-offs (documented in code)
- The history cache is append-only — message edits or deletes inside the cached window are not reflected. \`--no-cache\` forces a refetch.
- Custom \`channels list\` filters (\`--types\` other than the default, \`--cursor\`, \`--limit\`) bypass cache since the cache only stores the canonical public+private, non-archived set.

## Test plan
- [x] \`bunx vitest run\` — 377 pass (9 new in \`tests/cache.spec.ts\`, 2 new in \`tests/pagination.spec.ts\` covering the history append + \`--no-cache\` flow).
- [x] \`bun run src/index.ts slack channels list --help\` shows \`--no-cache\`.
- [ ] Manual: \`holla slack channels history --channel #general --all\` first run fetches everything; second run shows only new messages were fetched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Reuse cached Slack lists and keep channel history up to date with fewer refetches**

### What Changed
- Channel lists, user lists, and channel members now reuse local cache when you ask for the full list, so repeated commands return faster and avoid extra API calls.
- Channel history with `--all` now fetches only messages newer than the last saved message, then combines them with the cached history instead of downloading the full log again.
- `--no-cache` now lets you force a fresh fetch for any cached command on demand.
- Channel and user name lookup now uses the same cached lists as the `list` commands, so resolution stays aligned with the displayed data.
- Cache and config files now follow the current home directory at runtime, which fixes cases where tests or environment overrides were ignored.

### Impact
`✅ Faster repeated list commands`
`✅ Fewer Slack API calls for full history checks`
`✅ Fresh data on demand with --no-cache`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
